### PR TITLE
[BUGFIX] Use absolute image URLs in data-srcset if requested

### DIFF
--- a/Classes/ViewHelpers/ResponsiveImageViewHelper.php
+++ b/Classes/ViewHelpers/ResponsiveImageViewHelper.php
@@ -159,7 +159,7 @@ class ResponsiveImageViewHelper extends ImageViewHelper
             }
             $sizes = GeneralUtility::intExplode(',', $sizesCsv, true);
 
-            $srcSetString = $this->srcSetService->getSrcSetAttribute($image, $ratio, $maximumWidth, $maximumHeight, $crop, $cropVariant, $sizes);
+            $srcSetString = $this->srcSetService->getSrcSetAttribute($image, $ratio, $maximumWidth, $maximumHeight, $crop, $cropVariant, $sizes, $this->arguments['absolute']);
             $classNames = ['lazyload'];
             if (isset($this->arguments['class'])) {
                 $classNames[] = $this->arguments['class'];


### PR DESCRIPTION
Ensure that the `absolute` argument of the ResponsiveImageViewHelper is not only respected for the main image but also for the variants of the image  in the data-srcset attribute.